### PR TITLE
Add warnings for missing package information

### DIFF
--- a/.changeset/tricky-hats-promise.md
+++ b/.changeset/tricky-hats-promise.md
@@ -1,0 +1,10 @@
+---
+"astro-theme-provider": minor
+---
+
+Warn theme author about missing properties inside `package.json`:
+  - Check for `astro-integration` keyword inside `keywords` array
+  - Check for `description` property
+  - Check for `homepage` property
+  - Check for `repository` property
+  - Check for `README.md` at root of theme package

--- a/package/types.ts
+++ b/package/types.ts
@@ -14,6 +14,21 @@ export type ExportTypes = Record<
 	undefined | null | false | string | string[] | Record<string, string>
 >;
 
+export interface PackageJSON {
+	private?: boolean;
+	name?: string;
+	description?: string;
+	keywords?: string[];
+	homepage?: string;
+	repository?:
+		| string
+		| {
+				type: string;
+				url: string;
+				directory?: string;
+		  };
+}
+
 export type AuthorOptions<Config extends ConfigDefault> = Prettify<{
 	entrypoint?: string;
 	name?: ThemeName;

--- a/playground/package/package.json
+++ b/playground/package/package.json
@@ -1,8 +1,17 @@
 {
   "name": "my-theme",
   "private": true,
-  "description": "",
+  "description": "My awesome theme!",
   "license": "MIT",
+  "homepage": "https://github.com/UserName/my-theme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/UserName/my-theme",
+    "directory": "package"
+  },
+  "keywords": [
+    "astro-integration"
+  ],
   "scripts": {},
   "devDependencies": {
     "@types/node": "^20.11.19",


### PR DESCRIPTION
Warn theme author about missing properties inside `package.json`:
  - Check for `astro-integration` keyword inside `keywords` array
  - Check for `description` property
  - Check for `homepage` property
  - Check for `repository` property
  - Check for `README.md` at root of theme package