### PR TITLE
Update virtual import generation

### DIFF
--- a/.changeset/small-peas-crash.md
+++ b/.changeset/small-peas-crash.md
@@ -1,0 +1,5 @@
+---
+"astro-theme-provider": minor
+---
+
+Renamed author option `modules` to `imports`

--- a/.changeset/strong-gorillas-kneel.md
+++ b/.changeset/strong-gorillas-kneel.md
@@ -1,0 +1,5 @@
+---
+"astro-theme-provider": minor
+---
+
+Added support for `default` exports from theme imports

--- a/package/index.ts
+++ b/package/index.ts
@@ -27,13 +27,13 @@ import {
 	validatePattern,
 } from "./utils/path.ts";
 import {
-	toModuleObject,
 	createVirtualModule,
 	generateTypesFromModule,
 	globToModuleObject,
 	isEmptyModuleObject,
 	mergeModuleObjects,
 	resolveModuleObject,
+	toModuleObject,
 } from "./utils/virtual.ts";
 
 const thisFile = resolveFilepath("./", import.meta.url);
@@ -58,7 +58,7 @@ export default function <Schema extends z.ZodTypeAny>(partialAuthorOptions: Auth
 		pageDir: "pages",
 		publicDir: "public",
 		schema: z.record(z.any()),
-		modules: {
+		imports: {
 			css: GLOB_CSS,
 			assets: GLOB_IMAGES,
 			layouts: GLOB_ASTRO,
@@ -208,7 +208,7 @@ export default function <Schema extends z.ZodTypeAny>(partialAuthorOptions: Auth
 					});
 
 					// Dynamically create virtual modules using globs, imports, or exports
-					for (let [name, option] of Object.entries(authorOptions.modules)) {
+					for (let [name, option] of Object.entries(authorOptions.imports)) {
 						if (!option) continue;
 
 						// Reserved module/import names
@@ -359,7 +359,7 @@ export default function <Schema extends z.ZodTypeAny>(partialAuthorOptions: Auth
 							}
 						`;
 					}
-					
+
 					// Write compiled types to .d.ts file
 					addDts({
 						name: themeName,

--- a/package/types.ts
+++ b/package/types.ts
@@ -31,7 +31,7 @@ export type AuthorOptions<Schema extends z.ZodTypeAny> = Prettify<{
 	publicDir?: string | StaticDirOption;
 	pageDir?: string | PageDirOption;
 	schema?: Schema;
-	modules?: Record<string, string | ModuleImports | ModuleExports | ModuleObject>;
+	imports?: Record<string, string | ModuleImports | ModuleExports | ModuleObject>;
 }>;
 
 export type UserOptions<Schema extends z.ZodTypeAny> = Prettify<{

--- a/package/utils/options.ts
+++ b/package/utils/options.ts
@@ -1,31 +1,29 @@
 export function mergeOptions(target: Record<any, any>, source: Record<any, any>) {
-	const merge = { ...target };
-
 	for (const key in source) {
 		const value = source[key];
 
 		if (typeof value === "object" && value !== null) {
-			if (Array.isArray(value) && Array.isArray(merge[key])) {
+			if (Array.isArray(value) && Array.isArray(target[key])) {
 				// Combine array values
-				merge[key].push(...value);
+				target[key].push(...value);
 				continue;
 			}
 
 			if (
-				typeof merge[key] === "object" &&
-				merge[key] !== null &&
+				typeof target[key] === "object" &&
+				target[key] !== null &&
 				// Skip zod schemas
 				!("_def" in value)
 			) {
 				// Combine object values
-				merge[key] = mergeOptions(merge[key], value);
+				target[key] = mergeOptions(target[key], value);
 				continue;
 			}
 		}
 
 		// Overwrite all other values
-		merge[key] = value;
+		target[key] = value;
 	}
 
-	return merge;
+	return target;
 }

--- a/package/utils/virtual.ts
+++ b/package/utils/virtual.ts
@@ -4,18 +4,20 @@ import { GLOB_IGNORE } from "./consts.ts";
 import { mergeOptions } from "./options.ts";
 import { isCSSFile, isImageFile, normalizePath } from "./path.ts";
 
+const RESOLVED = Symbol("resolved");
+
 export type ImportOption = string | false | null | undefined;
 
 export type ModuleImports = (ImportOption | ModuleImports)[];
 
-export interface ModuleExports {
-	[name: string]: ImportOption;
-}
-
 export type ResolvedModuleImports = string[];
 
+export interface ModuleExports {
+	[id: string]: ImportOption;
+}
+
 export interface ResolvedModuleExports {
-	[name: string]: string;
+	[id: string]: string;
 }
 
 export interface ModuleObject {
@@ -24,76 +26,49 @@ export interface ModuleObject {
 }
 
 export interface ResolvedModuleObject extends ModuleObject {
-	resolved: true;
+	root: string;
 	imports: ResolvedModuleImports;
 	exports: ResolvedModuleExports;
+	[RESOLVED]: true;
 }
 
 export interface VirtualModule extends ResolvedModuleObject {
 	name: string;
-	content: string;
-}
-
-function camelCase(str: string) {
-	return str.replace(/(-|<|>|:|"|\/|\\|\||\?|\*|\s)./g, (x) => x[1]!.toUpperCase());
-}
-
-function shouldBeNamespaceImport(path: string) {
-	return isCSSFile(path);
-}
-
-function resolveId(id: string, base = "./") {
-	return normalizePath(id.startsWith(".") ? resolve(base, id) : id);
-}
-
-function resolveImportArray(imports: ModuleImports, store?: Set<string>): ResolvedModuleImports {
-	store ||= new Set<string>();
-
-	if (imports) {
-		for (const i of imports) {
-			if (!i) continue;
-			if (Array.isArray(i)) {
-				resolveImportArray(i, store);
-				continue;
-			}
-			store.add(resolveId(i));
-		}
-	}
-
-	return Array.from(store);
-}
-
-export function isEmptyModuleObject(option: ModuleImports | ModuleExports | ModuleObject | VirtualModule): boolean {
-	if (Array.isArray(option)) {
-		option = { imports: option, exports: {} };
-	}
-
-	const { imports = [], exports = option } = option;
-
-	return (!imports || !!imports.length) && (!exports || !!Object.keys(exports).length);
-}
-
-export function resolveExportObject(exports: ModuleExports): ResolvedModuleExports {
-	const resolved: ResolvedModuleExports = {};
-
-	for (const [name, path] of Object.entries(exports)) {
-		if (!path) continue;
-		resolved[camelCase(name)] = resolveId(path);
-	}
-
-	return resolved;
-}
-
-export function resolveModuleObject(module: ModuleObject): ResolvedModuleObject {
-	const { imports = [], exports = {} } = module;
-	return {
-		resolved: true,
-		imports: resolveImportArray(imports),
-		exports: resolveExportObject(exports),
+	merge: (source: ResolvedModuleObject | VirtualModule) => void;
+	content: (content?: string) => string;
+	types: {
+		module: () => string;
+		interface: () => string;
 	};
 }
 
-export function convertToModuleObject(option: ModuleImports | ModuleExports | ModuleObject): ModuleObject {
+export function camelCase(str: string) {
+	return str.replace(/(-|<|>|:|"|\/|\\|\||\?|\*|\s)./g, (x) => x[1]!.toUpperCase());
+}
+
+export function resolveId(root: string, id: string) {
+	return normalizePath(id.startsWith(".") ? resolve(root || "./", id) : id);
+}
+
+export function isSideEffectImport(path: string) {
+	return isCSSFile(path);
+}
+
+export function isEmptyModuleObject({
+	imports = [],
+	exports = {},
+}: ModuleObject | ResolvedModuleObject | VirtualModule): boolean {
+	return !!imports?.length && !!Object.keys(exports || {}).length;
+}
+
+export function mergeModuleObjects<T extends S, S extends ModuleObject | ResolvedModuleObject | VirtualModule>(
+	target: T,
+	{ imports = [], exports = {} }: S,
+): T {
+	return mergeOptions(target, { imports, exports }) as T;
+}
+
+export function toModuleObject(option: ModuleImports | ModuleExports | ModuleObject): ModuleObject {
 	if (Array.isArray(option)) {
 		option = { imports: option, exports: {} };
 	}
@@ -103,14 +78,53 @@ export function convertToModuleObject(option: ModuleImports | ModuleExports | Mo
 	return { imports, exports };
 }
 
-export function globToModuleObject(cwd: string, glob: string | string[]): ModuleObject {
-	const files = fg.sync([glob, GLOB_IGNORE].flat(), { cwd, absolute: true });
+export function resolveImportArray(root: string, imports: ModuleImports, store?: Set<string>): ResolvedModuleImports {
+	store ||= new Set<string>();
 
-	const exports: ModuleExports = {};
-	const imports: ModuleImports = [];
+	for (const i of imports) {
+		if (!i) continue;
+		if (Array.isArray(i)) {
+			resolveImportArray(root, i, store);
+			continue;
+		}
+		store.add(resolveId(root, i));
+	}
+
+	return Array.from(store);
+}
+
+export function resolveExportObject(root: string, exports: ModuleExports): ResolvedModuleExports {
+	const resolved: ResolvedModuleExports = {};
+	for (const name in exports) {
+		const id = exports[name];
+		if (!id) continue;
+		resolved[camelCase(name)] = resolveId(root, id);
+	}
+	return resolved;
+}
+
+export function resolveModuleObject(
+	root: string,
+	module: ModuleObject | ResolvedModuleObject | VirtualModule,
+): ResolvedModuleObject {
+	if (RESOLVED in module) return module;
+	const { imports = [], exports = {} } = module;
+	return {
+		root,
+		imports: resolveImportArray(root, imports),
+		exports: resolveExportObject(root, exports),
+		[RESOLVED]: true,
+	};
+}
+
+export function globToModuleObject(root: string, glob: string | string[]): ResolvedModuleObject {
+	const files = fg.sync([glob, GLOB_IGNORE].flat(), { cwd: root, absolute: true });
+
+	const imports: ResolvedModuleImports = [];
+	const exports: ResolvedModuleExports = {};
 
 	for (const file of files.reverse()) {
-		if (shouldBeNamespaceImport(file)) {
+		if (isSideEffectImport(file)) {
 			imports.push(file);
 			continue;
 		}
@@ -119,42 +133,39 @@ export function globToModuleObject(cwd: string, glob: string | string[]): Module
 	}
 
 	return {
+		root,
 		imports,
 		exports,
+		[RESOLVED]: true,
 	};
 }
 
-export function createVirtualModule(name: string, module: ModuleObject): VirtualModule {
-	const resolved = resolveModuleObject(module);
-	return {
+export function createVirtualModule(
+	name: string,
+	root: string,
+	module: ModuleObject | ResolvedModuleObject,
+): VirtualModule {
+	const resolved = resolveModuleObject(root, module);
+
+	const virtual: VirtualModule = {
 		name,
-		content: getModuleObjectContent(resolved),
 		...resolved,
+		merge: (source) => mergeModuleObjects(virtual, source),
+		content: (content) => generateModuleContent(virtual, content),
+		types: {
+			module: () => generateModuleTypes(virtual),
+			interface: () => generateInterfaceTypes(virtual),
+		},
 	};
+
+	return virtual;
 }
 
-export function mergeIntoModuleObject<T extends S, S extends ModuleObject | ResolvedModuleObject | VirtualModule>(
-	target: T,
-	source: S,
-): T {
-	if (!(source as ResolvedModuleObject)?.resolved) {
-		source = resolveModuleObject(source) as S;
-	}
-
-	target = mergeOptions(target, source) as T;
-
-	if ("content" in target) {
-		target.content = getModuleObjectContent(target);
-	}
-
-	return target;
+export function generateModuleContent({ imports, exports }: ResolvedModuleObject | VirtualModule, content = "") {
+	return `${generateModuleImportContent(imports)}\n${content}\n${generateModuleExportContent(exports)}`;
 }
 
-export function getModuleObjectContent({ imports, exports }: ResolvedModuleObject | VirtualModule) {
-	return `${getModuleImportsContent(imports)}\n${getModuleExportsContent(exports)}`;
-}
-
-export function getModuleImportsContent(imports: ResolvedModuleImports) {
+export function generateModuleImportContent(imports: ResolvedModuleImports) {
 	let buffer = "";
 
 	for (const path of imports) {
@@ -164,11 +175,16 @@ export function getModuleImportsContent(imports: ResolvedModuleImports) {
 	return buffer;
 }
 
-export function getModuleExportsContent(exports: ResolvedModuleExports) {
+export function generateModuleExportContent(exports: ResolvedModuleExports) {
 	let buffer = "";
 
 	for (const [name, path] of Object.entries(exports || {})) {
-		if (!path || shouldBeNamespaceImport(path)) continue;
+		if (!path || isSideEffectImport(path)) continue;
+
+		if (name === "default") {
+			buffer += `export default ${JSON.stringify(path)}`;
+			continue;
+		}
 
 		buffer += `\nexport { default as ${name} } from ${JSON.stringify(path)};`;
 	}
@@ -176,7 +192,20 @@ export function getModuleExportsContent(exports: ResolvedModuleExports) {
 	return buffer;
 }
 
-export function generateModuleObjectTypes(
+// Generate Types
+
+export function generateInterfaceTypes(option: Parameters<typeof generateTypesFromModule>[0]) {
+	return generateTypesFromModule(option, ({ name, type }) => `\n${name}: ${type};`);
+}
+
+export function generateModuleTypes(option: Parameters<typeof generateTypesFromModule>[0]) {
+	return generateTypesFromModule(option, ({ name, type }) => name === 'default'
+		? `\nconst _default: ${type};\nexport default _default;`
+		: `\nexport const ${name}: ${type};`
+	);
+}
+
+export function generateTypesFromModule(
 	module: ResolvedModuleObject | VirtualModule,
 	generate: ({ name, path, type }: { name: string; path: string; type: string }) => string,
 ) {
@@ -185,14 +214,14 @@ export function generateModuleObjectTypes(
 	const { exports } = module;
 
 	for (const [name, path] of Object.entries(exports || {})) {
-		if (!path || shouldBeNamespaceImport(path)) continue;
+		if (!path || isSideEffectImport(path)) continue;
 
 		let type;
 
 		if (isImageFile(path)) {
-			type = `import("astro").ImageMetadata;`;
+			type = `import("astro").ImageMetadata`;
 		} else {
-			type = `typeof import(${JSON.stringify(path)}).default;`;
+			type = `typeof import(${JSON.stringify(path)}).default`;
 		}
 
 		const line = generate({ name, path, type });

--- a/package/utils/virtual.ts
+++ b/package/utils/virtual.ts
@@ -199,9 +199,8 @@ export function generateInterfaceTypes(option: Parameters<typeof generateTypesFr
 }
 
 export function generateModuleTypes(option: Parameters<typeof generateTypesFromModule>[0]) {
-	return generateTypesFromModule(option, ({ name, type }) => name === 'default'
-		? `\nconst _default: ${type};\nexport default _default;`
-		: `\nexport const ${name}: ${type};`
+	return generateTypesFromModule(option, ({ name, type }) =>
+		name === "default" ? `\nconst _default: ${type};\nexport default _default;` : `\nexport const ${name}: ${type};`,
 	);
 }
 

--- a/playground/package/index.ts
+++ b/playground/package/index.ts
@@ -6,4 +6,9 @@ export default defineTheme({
 		title: z.string(),
 		description: z.string().optional(),
 	}),
+	modules: {
+		test: {
+			default: "./src/components/Heading.astro",
+		},
+	},
 });


### PR DESCRIPTION
- Rename author option `modules` to `imports`
- Add support for `default` exports for theme imports
- Refactor virtual import generation
  - Refactor types/function signatures to fit new workflow between utilities
  - Added symbol for detecting resolved module objects
  - Rename functions/variables for better readability
  - Content/type generation for virtual modules is now dynamic
  - `mergeOption` utility now merges directly onto the target instead of making a copy