### PR TITLE
Add LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "astro-theme-provider",
-	"version": "0.0.3",
+	"version": "0.1.1",
 	"description": "Easily create theme integrations for Astro",
 	"keywords": ["astro", "withastro", "astro-integration"],
 	"author": "Bryce Russell",
@@ -11,7 +11,7 @@
 		"directory": "packages/astro-theme-provider"
 	},
 	"bugs": "https://github.com/brycerussell/astro-theme-provider/issues",
-	"homepage": "https://github.com/brycerussell/astro-theme-provider",
+	"homepage": "https://astro-theme-provider.netlify.app/",
 	"scripts": {},
 	"type": "module",
 	"exports": {

--- a/package/package.json
+++ b/package/package.json
@@ -4,7 +4,7 @@
 	"description": "Easily create theme integrations for Astro",
 	"keywords": ["astro", "withastro", "astro-integration"],
 	"author": "Bryce Russell",
-	"license": "MIT",
+	"license": "Unlicense",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/brycerussell/astro-theme-provider",
@@ -15,8 +15,7 @@
 	"scripts": {},
 	"type": "module",
 	"exports": {
-		".": "./index.ts",
-		"./types": "./types.ts"
+		".": "./index.ts"
 	},
 	"peerDependencies": {
 		"@astrojs/db": ">=0.8.0",


### PR DESCRIPTION
The main purpose of this PR is to bring the package `version` inline with published version

I tried releasing ATP as a beta for people to try without realizing that the published version is independent of the tag being used to publish. When ATP is ready to release, it will have to release as `0.2.0` instead of `0.1.0` which will now be considered "beta"

Also:
- Update package homepage to be linked to docs
- Removes `types` export for now
- Add LICENSE
- Set license to `Unlicense`