### PR TITLE
Fix typing for themes

### DIFF
--- a/.changeset/little-shrimps-hang.md
+++ b/.changeset/little-shrimps-hang.md
@@ -1,0 +1,5 @@
+---
+"astro-theme-provider": minor
+---
+
+Fixed typing for theme integrations, `name` property is now required again

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -163,7 +163,7 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 														[Module in keyof ThemeExports]?:
 																ThemeExports[Module] extends Record<string, any>
 																		? ThemeExports[Module] extends string[]
-																				?	ThemeExports[Module]
+																				?	string[]
 																				: { [Export in keyof ThemeExports[Module]]?: string }
 																		: never
 												} & {};
@@ -211,7 +211,7 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 
 						// Add generated types to interface buffer
 						interfaceBuffers.ThemeExports += `
-							"${name}": ${interfaceTypes ? `{\n${interfaceTypes}\n}` : "string[]"},
+							"${name}": ${interfaceTypes ? `{\n${interfaceTypes}\n}` : JSON.stringify(virtualModule.imports)},
 						`;
 
 						const override = userOverrides[name];
@@ -249,7 +249,7 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 
 						// Add generated types to interface buffer
 						interfaceBuffers.ThemeExportsResolved += `
-							"${name}": ${interfaceTypes ? `{\n${interfaceTypes}\n}` : "string[]"},
+							"${name}": ${interfaceTypes ? `{\n${interfaceTypes}\n}` : JSON.stringify(virtualModule.imports)},
 						`;
 					}
 

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,6 +1,7 @@
 // import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { AstroIntegration } from "astro";
 // import type { AstroDbIntegration } from "@astrojs/db/types";
 import { addDts, addIntegration, addVirtualImports, watchIntegration } from "astro-integration-kit";
 import "astro-integration-kit/types/db";
@@ -25,12 +26,13 @@ import {
 	validatePattern,
 } from "./utils/path.js";
 import { createVirtualModule, globToModuleObject, isEmptyModuleObject, toModuleObject } from "./utils/virtual.js";
-import type { AstroIntegration } from "astro";
 
-const thisFile = resolveFilepath( "./", import.meta.url);
+const thisFile = resolveFilepath("./", import.meta.url);
 const thisRoot = resolveDirectory("./", thisFile);
 
-export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(partialAuthorOptions: AuthorOptions<ThemeName, Schema>) {
+export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
+	partialAuthorOptions: AuthorOptions<ThemeName, Schema>,
+) {
 	// Theme package entrypoint (/package/index.ts)
 	const themeEntrypoint = callsites()
 		.reverse()
@@ -340,6 +342,6 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 			},
 		};
 
-		return themeIntegration
+		return themeIntegration;
 	};
 }

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -121,7 +121,10 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 
 					// Module type buffers
 					const moduleBuffers: Record<string, string> = {
-						[`${themeName}/config`]: "\nconst config: ThemeConfig;\nexport default config;",
+						[`${themeName}/config`]: `
+							const config: NonNullable<NonNullable<Parameters<typeof import("${themeEntrypoint}").default>[0]>["config"]>;
+							export default config;
+						`,
 					};
 
 					// Interface type buffers

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,10 +1,8 @@
-// import { existsSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { AstroIntegration } from "astro";
-// import type { AstroDbIntegration } from "@astrojs/db/types";
+import type { AstroDbIntegration } from "@astrojs/db/types";
 import { addDts, addIntegration, addVirtualImports, watchIntegration } from "astro-integration-kit";
-import "astro-integration-kit/types/db";
 import { addPageDir } from "astro-pages";
 import type { IntegrationOption as PageDirIntegrationOption, Option as PageDirOption } from "astro-pages/types";
 import staticDir from "astro-public";
@@ -101,16 +99,16 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 
 		const userConfig = parsed.data;
 
-		const themeIntegration: AstroIntegration = {
+		const themeIntegration: AstroDbIntegration = {
 			name: themeName,
 			hooks: {
 				// Support `@astrojs/db` (Astro Studio)
-				// "astro:db:setup": ({ extendDb }) => {
-				// 	const configEntrypoint = resolve(themeRoot, "db/cofig.ts");
-				// 	const seedEntrypoint = resolve(themeRoot, "db/seed.ts");
-				// 	if (existsSync(configEntrypoint)) extendDb({ configEntrypoint });
-				// 	if (existsSync(seedEntrypoint)) extendDb({ seedEntrypoint });
-				// },
+				"astro:db:setup": ({ extendDb }) => {
+					const configEntrypoint = resolve(themeRoot, "db/cofig.ts");
+					const seedEntrypoint = resolve(themeRoot, "db/seed.ts");
+					if (existsSync(configEntrypoint)) extendDb({ configEntrypoint });
+					if (existsSync(seedEntrypoint)) extendDb({ seedEntrypoint });
+				},
 				"astro:config:setup": (params) => {
 					const { config, logger, injectRoute } = params;
 

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,7 +1,7 @@
-import { existsSync } from "node:fs";
+// import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { AstroDbIntegration } from "@astrojs/db/types";
+// import type { AstroDbIntegration } from "@astrojs/db/types";
 import { addDts, addIntegration, addVirtualImports, watchIntegration } from "astro-integration-kit";
 import "astro-integration-kit/types/db";
 import { addPageDir } from "astro-pages";
@@ -25,11 +25,12 @@ import {
 	validatePattern,
 } from "./utils/path.js";
 import { createVirtualModule, globToModuleObject, isEmptyModuleObject, toModuleObject } from "./utils/virtual.js";
+import type { AstroIntegration } from "astro";
 
-const thisFile = resolveFilepath("./", import.meta.url);
+const thisFile = resolveFilepath( "./", import.meta.url);
 const thisRoot = resolveDirectory("./", thisFile);
 
-export default function <Schema extends z.ZodTypeAny>(partialAuthorOptions: AuthorOptions<Schema>) {
+export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(partialAuthorOptions: AuthorOptions<ThemeName, Schema>) {
 	// Theme package entrypoint (/package/index.ts)
 	const themeEntrypoint = callsites()
 		.reverse()
@@ -51,7 +52,7 @@ export default function <Schema extends z.ZodTypeAny>(partialAuthorOptions: Auth
 			layouts: GLOB_ASTRO,
 			components: GLOB_COMPONENTS,
 		},
-	} as Required<AuthorOptions<z.ZodRecord>>;
+	} as Required<AuthorOptions<string, z.ZodRecord>>;
 
 	if (typeof authorOptions.pageDir === "string") {
 		authorOptions.pageDir = { dir: authorOptions.pageDir } as PageDirOption;
@@ -62,7 +63,7 @@ export default function <Schema extends z.ZodTypeAny>(partialAuthorOptions: Auth
 	}
 
 	// Merge author options with default options
-	authorOptions = mergeOptions(authorOptions, partialAuthorOptions) as Required<AuthorOptions<z.ZodRecord>>;
+	authorOptions = mergeOptions(authorOptions, partialAuthorOptions) as Required<AuthorOptions<string, z.ZodRecord>>;
 
 	// Theme package root (/package)
 	const themeRoot = resolveDirectory("./", authorOptions.entrypoint);
@@ -74,7 +75,7 @@ export default function <Schema extends z.ZodTypeAny>(partialAuthorOptions: Auth
 	authorOptions = mergeOptions(authorOptions, {
 		pageDir: { cwd: themeSrc },
 		publicDir: { cwd: themeSrc },
-	}) as Required<AuthorOptions<z.ZodRecord>>;
+	}) as Required<AuthorOptions<string, z.ZodRecord>>;
 
 	// Theme `package.json`
 	const themePackage = new PackageJSON(themeRoot);
@@ -83,7 +84,7 @@ export default function <Schema extends z.ZodTypeAny>(partialAuthorOptions: Auth
 	const themeName = authorOptions.name || themePackage.json.name || "theme-integration";
 
 	// Return theme integration
-	return (userOptions: UserOptions<Schema> = {}): AstroDbIntegration => {
+	return (userOptions: UserOptions<ThemeName, Schema> = {}) => {
 		const { config: userConfigUnparsed = {}, pages: userPages = {}, overrides: userOverrides = {} } = userOptions;
 
 		// Parse/validate config passed by user, throw formatted error if it is invalid
@@ -98,16 +99,16 @@ export default function <Schema extends z.ZodTypeAny>(partialAuthorOptions: Auth
 
 		const userConfig = parsed.data;
 
-		return {
+		const themeIntegration: AstroIntegration = {
 			name: themeName,
 			hooks: {
 				// Support `@astrojs/db` (Astro Studio)
-				"astro:db:setup": ({ extendDb }) => {
-					const configEntrypoint = resolve(themeRoot, "db/cofig.ts");
-					const seedEntrypoint = resolve(themeRoot, "db/seed.ts");
-					if (existsSync(configEntrypoint)) extendDb({ configEntrypoint });
-					if (existsSync(seedEntrypoint)) extendDb({ seedEntrypoint });
-				},
+				// "astro:db:setup": ({ extendDb }) => {
+				// 	const configEntrypoint = resolve(themeRoot, "db/cofig.ts");
+				// 	const seedEntrypoint = resolve(themeRoot, "db/seed.ts");
+				// 	if (existsSync(configEntrypoint)) extendDb({ configEntrypoint });
+				// 	if (existsSync(seedEntrypoint)) extendDb({ seedEntrypoint });
+				// },
 				"astro:config:setup": (params) => {
 					const { config, logger, injectRoute } = params;
 
@@ -125,39 +126,48 @@ export default function <Schema extends z.ZodTypeAny>(partialAuthorOptions: Auth
 
 					// Interface type buffers
 					const interfaceBuffers = {
-						AstroThemeExports: "",
+						ThemeExports: "",
 						AstroThemeExportOverrides: "",
-						AstroThemeExportsResolved: "",
-						AstroThemePagesAuthored: "",
+						ThemeExportsResolved: "",
+						ThemeRoutes: "",
 						AstroThemePagesOverrides: "",
 					};
 
 					let themeTypesBuffer = `
-						type Prettify<T> = { [K in keyof T]: T[K]; } & {};
-
 						type ThemeName = "${themeName}";
-						type ThemeConfig = NonNullable<Parameters<typeof import("${themeEntrypoint}").default>[0]>["config"]
+						type ThemeConfig = NonNullable<NonNullable<Parameters<typeof import("C:/Users/Bryce/Desktop/Projects/Astro/astro-theme-provider/tests/themes/theme-playground/index.ts").default>[0]>["config"]>
 
-						declare type AstroThemes = keyof AstroThemeConfigs;
-
-						declare type AstroThemeConfigs = {
-							"${themeName}": ThemeConfig
-						}
-
-						declare type GetAstroThemeExports<Name extends keyof AstroThemeConfigs> = AstroThemeExports[Name]
-
-						declare type AstroThemeExportOverrideOptions<Name extends keyof AstroThemeConfigs, Imports = GetAstroThemeExports<Name>> = {
-							[Module in keyof Imports]?:
-								Imports[Module] extends Record<string, any>
-									? Imports[Module] extends string[]
-										?	Imports[Module]
-										: { [Export in keyof Imports[Module]]?: string }
-									: never
-						} & {}
+						declare namespace AstroThemeProvider {
+								export interface Themes {
+										"${themeName}": true;
+								}
 						
-						declare type AstroThemePagesOverridesOptions<Name extends keyof AstroThemePagesAuthored> = Prettify<Partial<Record<keyof AstroThemePagesAuthored[Name], string | boolean>>>
-
-						declare type AstroThemePagesInjected = AstroThemePagesOverrides & AstroThemePagesAuthored
+								export interface ThemeConfigs {
+										"${themeName}": ThemeConfig;
+								};
+						
+								export interface ThemePages {
+										"${themeName}": ThemeRoutes
+								}
+						
+								export interface ThemeOverrides {
+										"${themeName}": ThemeExports
+								}
+						
+								export interface ThemeOptions {
+										"${themeName}": {
+												pages?: { [Pattern in keyof ThemeRoutes]?: string | boolean }
+												overrides?: {
+														[Module in keyof ThemeExports]?:
+																ThemeExports[Module] extends Record<string, any>
+																		? ThemeExports[Module] extends string[]
+																				?	ThemeExports[Module]
+																				: { [Export in keyof ThemeExports[Module]]?: string }
+																		: never
+												} & {};
+										};
+								}
+						}
 					`;
 
 					// Warn about issues with theme's `package.json`
@@ -198,7 +208,7 @@ export default function <Schema extends z.ZodTypeAny>(partialAuthorOptions: Auth
 						let interfaceTypes = virtualModule.types.interface();
 
 						// Add generated types to interface buffer
-						interfaceBuffers.AstroThemeExports += `
+						interfaceBuffers.ThemeExports += `
 							"${name}": ${interfaceTypes ? `{\n${interfaceTypes}\n}` : "string[]"},
 						`;
 
@@ -236,7 +246,7 @@ export default function <Schema extends z.ZodTypeAny>(partialAuthorOptions: Auth
 						interfaceTypes = virtualModule.types.interface();
 
 						// Add generated types to interface buffer
-						interfaceBuffers.AstroThemeExportsResolved += `
+						interfaceBuffers.ThemeExportsResolved += `
 							"${name}": ${interfaceTypes ? `{\n${interfaceTypes}\n}` : "string[]"},
 						`;
 					}
@@ -251,7 +261,7 @@ export default function <Schema extends z.ZodTypeAny>(partialAuthorOptions: Auth
 					const { pages, injectPages } = addPageDir(pageDirOption);
 
 					// Generate types for possibly injected routes
-					interfaceBuffers.AstroThemePagesAuthored += Object.entries(pages)
+					interfaceBuffers.ThemeRoutes += Object.entries(pages)
 						.map(([pattern, entrypoint]) => `\n"${pattern}": typeof import("${entrypoint}").default`)
 						.join("");
 
@@ -305,10 +315,8 @@ export default function <Schema extends z.ZodTypeAny>(partialAuthorOptions: Auth
 					for (const [name, buffer] of Object.entries(interfaceBuffers)) {
 						if (!buffer) continue;
 						themeTypesBuffer += `
-							declare interface ${name} {
-								"${themeName}": {
-									${buffer}
-								}
+							interface ${name} {
+								${buffer}
 							}
 						`;
 					}
@@ -331,5 +339,7 @@ export default function <Schema extends z.ZodTypeAny>(partialAuthorOptions: Auth
 				},
 			},
 		};
+
+		return themeIntegration
 	};
 }

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -81,7 +81,7 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 	const themePackage = new PackageJSON(themeRoot);
 
 	// Assign theme name
-	const themeName = authorOptions.name || themePackage.json.name || "theme-integration";
+	const themeName = authorOptions.name;
 
 	// Return theme integration
 	return (userOptions: UserOptions<ThemeName, Schema> = {}) => {

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -135,7 +135,7 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 
 					let themeTypesBuffer = `
 						type ThemeName = "${themeName}";
-						type ThemeConfig = NonNullable<NonNullable<Parameters<typeof import("C:/Users/Bryce/Desktop/Projects/Astro/astro-theme-provider/tests/themes/theme-playground/index.ts").default>[0]>["config"]>
+						type ThemeConfig = NonNullable<NonNullable<Parameters<typeof import("${themeEntrypoint}").default>[0]>["config"]>
 
 						declare namespace AstroThemeProvider {
 								export interface Themes {

--- a/package/src/internal/types.ts
+++ b/package/src/internal/types.ts
@@ -35,14 +35,18 @@ export type AuthorOptions<ThemeName extends string, Schema extends z.ZodTypeAny>
 }>;
 
 export type UserOptions<ThemeName extends string, Schema extends z.ZodTypeAny = z.ZodTypeAny> = {
-	config?: z.infer<Schema>,
-} & AstroThemeProvider.ThemeOptions[ThemeName]
+	config?: z.infer<Schema>;
+} & AstroThemeProvider.ThemeOptions[ThemeName];
 
 declare global {
 	namespace AstroThemeProvider {
-		export interface ThemeOptions extends Record<string, {
-			pages?: Record<string, string | boolean>
-			overrides?: Record<string, string[] | Record<string, string>>
-		}> {}
+		export interface ThemeOptions
+			extends Record<
+				string,
+				{
+					pages?: Record<string, string | boolean>;
+					overrides?: Record<string, string[] | Record<string, string>>;
+				}
+			> {}
 	}
 }

--- a/package/src/internal/types.ts
+++ b/package/src/internal/types.ts
@@ -25,7 +25,7 @@ export interface PackageJSONOptions {
 }
 
 export type AuthorOptions<ThemeName extends string, Schema extends z.ZodTypeAny> = Prettify<{
-	name?: ThemeName;
+	name: ThemeName;
 	entrypoint?: string;
 	srcDir?: string;
 	publicDir?: string | StaticDirOption;

--- a/package/src/internal/types.ts
+++ b/package/src/internal/types.ts
@@ -24,7 +24,7 @@ export interface PackageJSONOptions {
 		  };
 }
 
-export type AuthorOptions<Schema extends z.ZodTypeAny> = Prettify<{
+export type AuthorOptions<ThemeName extends string, Schema extends z.ZodTypeAny> = Prettify<{
 	name?: ThemeName;
 	entrypoint?: string;
 	srcDir?: string;
@@ -34,13 +34,15 @@ export type AuthorOptions<Schema extends z.ZodTypeAny> = Prettify<{
 	imports?: Record<string, string | ModuleImports | ModuleExports | ModuleObject>;
 }>;
 
-export type UserOptions<Schema extends z.ZodTypeAny> = Prettify<{
-	config?: z.infer<Schema>;
-	pages?: AstroThemePagesOverridesOptions<ThemeName> | undefined;
-	overrides?: AstroThemeExportOverrideOptions<ThemeName> | undefined;
-}>;
+export type UserOptions<ThemeName extends string, Schema extends z.ZodTypeAny = z.ZodTypeAny> = {
+	config?: z.infer<Schema>,
+} & AstroThemeProvider.ThemeOptions[ThemeName]
 
-// Temporary until refactor on type-gen
-declare type ThemeName = "";
-declare type AstroThemePagesOverridesOptions<T extends ThemeName> = Record<string, string | boolean>;
-declare type AstroThemeExportOverrideOptions<T extends ThemeName> = Record<string, string[] | Record<string, string>>;
+declare global {
+	namespace AstroThemeProvider {
+		export interface ThemeOptions extends Record<string, {
+			pages?: Record<string, string | boolean>
+			overrides?: Record<string, string[] | Record<string, string>>
+		}> {}
+	}
+}

--- a/package/tests/mock/project/src/env.d.ts
+++ b/package/tests/mock/project/src/env.d.ts
@@ -1,4 +1,3 @@
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
 /// <reference types="../.astro/theme-mock.d.ts" />
-/// <reference types="../.astro/theme-playground.d.ts" />

--- a/package/tests/theme.test.js
+++ b/package/tests/theme.test.js
@@ -26,7 +26,7 @@ const defaultModules = {
 };
 
 const defineTheme = (option) => {
-	return _defineTheme(Object.assign(option, { entrypoint: packageEntrypoint }));
+	return _defineTheme(Object.assign(option, { name: "theme-mock", entrypoint: packageEntrypoint }));
 };
 
 const resolveId = (id) => {

--- a/tests/themes/theme-playground/index.ts
+++ b/tests/themes/theme-playground/index.ts
@@ -2,6 +2,7 @@ import defineTheme from "astro-theme-provider";
 import { z } from "astro/zod";
 
 export default defineTheme({
+	name: "theme-playground",
 	schema: z.object({
 		title: z.string(),
 		description: z.string().optional(),

--- a/tests/themes/theme-ssg/index.ts
+++ b/tests/themes/theme-ssg/index.ts
@@ -2,6 +2,7 @@ import defineTheme from "astro-theme-provider";
 import { z } from "astro/zod";
 
 export default defineTheme({
+	name: "theme-ssg",
 	schema: z.object({
 		title: z.string(),
 		description: z.string().optional(),


### PR DESCRIPTION
Closes: https://github.com/BryceRussell/astro-theme-provider/issues/48

Had to add back the required `name` property for themes instead of inferring the name from the `package.json`