### PR TITLE
Change root directory for glob patterns

### DIFF
--- a/.changeset/sweet-ravens-hammer.md
+++ b/.changeset/sweet-ravens-hammer.md
@@ -1,0 +1,12 @@
+---
+"astro-theme-provider": minor
+---
+
+Updated root directory for glob modules, glob patterns are now relative to a theme's `srcDir`
+
+```diff
+ imports: {
+-  css: '**.css'
++  css: 'css/**.css'
+ }
+```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "root",
 	"private": true,
-	"packageManager": "pnpm@9.0.3",
+	"packageManager": "pnpm@9.0.4",
 	"engines": {
 		"node": ">=18.19.0"
 	},

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -47,10 +47,10 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 		publicDir: "public",
 		schema: z.record(z.any()),
 		imports: {
-			css: GLOB_CSS,
-			assets: GLOB_IMAGES,
-			layouts: GLOB_ASTRO,
-			components: GLOB_COMPONENTS,
+			css: `css/${GLOB_CSS}`,
+			assets: `assets/${GLOB_IMAGES}`,
+			layouts: `layouts/${GLOB_ASTRO}`,
+			components: `components/${GLOB_COMPONENTS}`,
 		},
 	} as Required<AuthorOptions<string, z.ZodRecord>>;
 
@@ -197,11 +197,10 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 						}
 
 						const moduleName = normalizePath(join(themeName, name));
-						const moduleRoot = normalizePath(resolve(themeSrc, name));
 
 						// Turn a glob string into a module object
 						if (typeof option === "string") {
-							option = globToModuleObject(moduleRoot, option);
+							option = globToModuleObject(themeSrc, option);
 						}
 
 						// Create virtual module object


### PR DESCRIPTION
This change allows theme authors to create virtual imports with any name when using glob patterns, instead of the name having to correspond to a folder in the `srcDir`