### PR TITLE
Add a `log` option for theme authors

### DIFF
--- a/.changeset/real-spies-tickle.md
+++ b/.changeset/real-spies-tickle.md
@@ -2,9 +2,9 @@
 "astro-theme-provider": minor
 ---
 
-- Added a `log` option for themes
+- Added a `log` option for theme authors
   - `false`: No logging
-  - `"minimal" | true`: Default logging, includes warning
+  - `"minimal" | true`: Default logging, includes warnings
   - `"verbose"`: Log everything, including debug information like page injection and static asset handling
 - Fixed warnings for a missing README throwing errors if README did not exist
   

--- a/.changeset/real-spies-tickle.md
+++ b/.changeset/real-spies-tickle.md
@@ -1,0 +1,12 @@
+---
+"astro-theme-provider": minor
+---
+
+- Added a `log` option for themes
+  - `false`: No logging
+  - `"minimal" | true`: Default logging, includes warning
+  - `"verbose"`: Log everything, including debug information like page injection and static asset handling
+- Fixed warnings for a missing README throwing errors if README did not exist
+  
+
+

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -173,8 +173,10 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 						}
 					`;
 
-					// Warn about issues with theme's `package.json`
-					warnThemePackage(themePackage, logger);
+					if (authorOptions.log) {
+						// Warn about issues with theme's `package.json`
+						warnThemePackage(themePackage, logger);
+					}
 
 					//HMR for `astro-theme-provider` package
 					watchIntegration(params, thisRoot);

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -45,6 +45,7 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 		srcDir: "src",
 		pageDir: "pages",
 		publicDir: "public",
+		log: true,
 		schema: z.record(z.any()),
 		imports: {
 			css: `css/${GLOB_CSS}`,

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -74,8 +74,8 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 
 	// Force options
 	authorOptions = mergeOptions(authorOptions, {
-		pageDir: { cwd: themeSrc },
-		publicDir: { cwd: themeRoot },
+		pageDir: { cwd: themeSrc, log: authorOptions.log },
+		publicDir: { cwd: themeRoot, log: authorOptions.log },
 	}) as Required<AuthorOptions<string, z.ZodRecord>>;
 
 	// Theme `package.json`

--- a/package/src/internal/types.ts
+++ b/package/src/internal/types.ts
@@ -30,7 +30,7 @@ export type AuthorOptions<ThemeName extends string, Schema extends z.ZodTypeAny>
 	srcDir?: string;
 	publicDir?: string | StaticDirOption;
 	pageDir?: string | PageDirOption;
-	log?: "verbose" | "minimal" | boolean
+	log?: "verbose" | "minimal" | boolean;
 	schema?: Schema;
 	imports?: Record<string, string | ModuleImports | ModuleExports | ModuleObject>;
 }>;

--- a/package/src/internal/types.ts
+++ b/package/src/internal/types.ts
@@ -30,6 +30,7 @@ export type AuthorOptions<ThemeName extends string, Schema extends z.ZodTypeAny>
 	srcDir?: string;
 	publicDir?: string | StaticDirOption;
 	pageDir?: string | PageDirOption;
+	log?: "verbose" | "minimal" | boolean
 	schema?: Schema;
 	imports?: Record<string, string | ModuleImports | ModuleExports | ModuleObject>;
 }>;

--- a/package/src/utils/package.ts
+++ b/package/src/utils/package.ts
@@ -77,7 +77,7 @@ export function warnThemePackage(pkg: PackageJSON, logger: HookParameters<"astro
 		}
 
 		// Warn theme author if package does not have a README
-		if (!existsSync(resolveFilepath(pkg.path, "README.md"))) {
+		if (!existsSync(resolveFilepath(pkg.path, "README.md", false))) {
 			logger.warn(
 				`Add a 'README.md' to the root of your theme's package!\tNPM uses this file to populate the package page https://www.npmjs.com/package/${pkg.json.name}\n`,
 			);

--- a/package/src/utils/package.ts
+++ b/package/src/utils/package.ts
@@ -36,38 +36,38 @@ export class PackageJSON {
 }
 
 export function warnThemePackage(pkg: PackageJSON, logger: HookParameters<"astro:config:setup">["logger"]) {
-	const { json } = pkg;
+	const { name, private: isPrivate, keywords = [], description, homepage, repository } = pkg.json;
 
 	// If package is not private, warn theme author about issues with package
-	if (!json.private) {
+	if (!isPrivate) {
 		// Warn theme author if `astro-integration` keyword does not exist inside 'package.json'
-		if (!json?.keywords?.includes("astro-integration")) {
+		if (!keywords.includes("astro-integration")) {
 			logger.warn(
-				`Add the 'astro-integration' keyword to your theme's 'package.json'!\tAstro uses this value to support the command 'astro add ${pkg.json.name}'\n\n\t"keywords": [ "astro-integration" ],\n`,
+				`Add the 'astro-integration' keyword to your theme's 'package.json'!\tAstro uses this value to support the command 'astro add ${name}'\n\n\t"keywords": [ "astro-integration" ],\n`,
 			);
 		}
 
 		// Warn theme author if no 'description' property exists inside 'package.json'
-		if (!json?.description) {
+		if (!description) {
 			logger.warn(
 				`Add a 'description' to your theme's 'package.json'!\tAstro uses this value to populate the integrations page https://astro.build/integrations/\n\n\t"description": "My awesome Astro theme!",\n`,
 			);
 		}
 
 		// Warn theme author if no 'homepage' property exists inside 'package.json'
-		if (!json?.homepage) {
+		if (!homepage) {
 			logger.warn(
 				`Add a 'homepage' to your theme's 'package.json'!\tAstro uses this value to populate the integrations page https://astro.build/integrations/\n\n\t"homepage": "https://github.com/UserName/theme-playground",\n`,
 			);
 		}
 
 		// Warn theme author if no 'repository' property exists inside 'package.json'
-		if (!json?.repository) {
+		if (!repository) {
 			logger.warn(
 				`Add a 'repository' to your theme's 'package.json'!\tAstro uses this value to populate the integrations page https://astro.build/integrations/\n\n\t"repository": ${JSON.stringify(
 					{
 						type: "git",
-						url: `https://github.com/UserName/${pkg.json.name}`,
+						url: `https://github.com/UserName/${name}`,
 						directory: "package",
 					},
 					null,
@@ -79,7 +79,7 @@ export function warnThemePackage(pkg: PackageJSON, logger: HookParameters<"astro
 		// Warn theme author if package does not have a README
 		if (!existsSync(resolveFilepath(pkg.path, "README.md", false))) {
 			logger.warn(
-				`Add a 'README.md' to the root of your theme's package!\tNPM uses this file to populate the package page https://www.npmjs.com/package/${pkg.json.name}\n`,
+				`Add a 'README.md' to the root of your theme's package!\tNPM uses this file to populate the package page https://www.npmjs.com/package/${name}\n`,
 			);
 		}
 	}


### PR DESCRIPTION
Fixed warnings for a missing README throwing errors if README did not exist

Added a `log` option for themes:
- `false`: No logging
- `"minimal" | true`: Default logging, includes warning
- `"verbose"`: Log everything, including debug information like page injection and static asset handling

**Example**:

```ts
import defineTheme from 'astro-theme-provider';

export default defineTheme({
	log: "verbose", // Log everything, including debug information
	name: "my-theme",
})
```
  
